### PR TITLE
archmigrator fixes: remove ppc64le, only try linux-aarch64

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -40,6 +40,70 @@ jobs:
         CONFIG: linux_64_nodejs22python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_nodejs20python3.10.____cpython:
+        CONFIG: linux_aarch64_nodejs20python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+      linux_aarch64_nodejs20python3.11.____cpython:
+        CONFIG: linux_aarch64_nodejs20python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+      linux_aarch64_nodejs20python3.12.____cpython:
+        CONFIG: linux_aarch64_nodejs20python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+      linux_aarch64_nodejs20python3.13.____cp313:
+        CONFIG: linux_aarch64_nodejs20python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+      linux_aarch64_nodejs22python3.10.____cpython:
+        CONFIG: linux_aarch64_nodejs22python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+      linux_aarch64_nodejs22python3.11.____cpython:
+        CONFIG: linux_aarch64_nodejs22python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+      linux_aarch64_nodejs22python3.12.____cpython:
+        CONFIG: linux_aarch64_nodejs22python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+      linux_aarch64_nodejs22python3.13.____cp313:
+        CONFIG: linux_aarch64_nodejs22python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+      linux_ppc64le_nodejs20python3.10.____cpython:
+        CONFIG: linux_ppc64le_nodejs20python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
+      linux_ppc64le_nodejs20python3.11.____cpython:
+        CONFIG: linux_ppc64le_nodejs20python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
+      linux_ppc64le_nodejs20python3.12.____cpython:
+        CONFIG: linux_ppc64le_nodejs20python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
+      linux_ppc64le_nodejs20python3.13.____cp313:
+        CONFIG: linux_ppc64le_nodejs20python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
+      linux_ppc64le_nodejs22python3.10.____cpython:
+        CONFIG: linux_ppc64le_nodejs22python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
+      linux_ppc64le_nodejs22python3.11.____cpython:
+        CONFIG: linux_ppc64le_nodejs22python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
+      linux_ppc64le_nodejs22python3.12.____cpython:
+        CONFIG: linux_ppc64le_nodejs22python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
+      linux_ppc64le_nodejs22python3.13.____cp313:
+        CONFIG: linux_ppc64le_nodejs22python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_nodejs20python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_nodejs20python3.10.____cpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+nodejs:
+- '20'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+rust_compiler:
+- rust
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_nodejs20python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_nodejs20python3.11.____cpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+nodejs:
+- '20'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+rust_compiler:
+- rust
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_nodejs20python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_nodejs20python3.12.____cpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+nodejs:
+- '20'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+rust_compiler:
+- rust
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_nodejs20python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_nodejs20python3.13.____cp313.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+nodejs:
+- '20'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+rust_compiler:
+- rust
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_nodejs22python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_nodejs22python3.10.____cpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+nodejs:
+- '22'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+rust_compiler:
+- rust
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_nodejs22python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_nodejs22python3.11.____cpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+nodejs:
+- '22'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+rust_compiler:
+- rust
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_nodejs22python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_nodejs22python3.12.____cpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+nodejs:
+- '22'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+rust_compiler:
+- rust
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_nodejs22python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_nodejs22python3.13.____cp313.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+nodejs:
+- '22'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+rust_compiler:
+- rust
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_ppc64le_nodejs20python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_nodejs20python3.10.____cpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
+nodejs:
+- '20'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+rust_compiler:
+- rust
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_nodejs20python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_nodejs20python3.11.____cpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
+nodejs:
+- '20'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+rust_compiler:
+- rust
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_nodejs20python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_nodejs20python3.12.____cpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
+nodejs:
+- '20'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+rust_compiler:
+- rust
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_nodejs20python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_nodejs20python3.13.____cp313.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
+nodejs:
+- '20'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+rust_compiler:
+- rust
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_nodejs22python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_nodejs22python3.10.____cpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
+nodejs:
+- '22'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+rust_compiler:
+- rust
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_nodejs22python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_nodejs22python3.11.____cpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
+nodejs:
+- '22'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+rust_compiler:
+- rust
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_nodejs22python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_nodejs22python3.12.____cpython.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
+nodejs:
+- '22'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+rust_compiler:
+- rust
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_nodejs22python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_nodejs22python3.13.____cp313.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
+nodejs:
+- '22'
+openssl:
+- '3'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+rust_compiler:
+- rust
+target_platform:
+- linux-ppc64le

--- a/README.md
+++ b/README.md
@@ -95,6 +95,118 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_nodejs20python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_nodejs20python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_nodejs20python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_nodejs20python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_nodejs20python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_nodejs20python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_nodejs20python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_nodejs20python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_nodejs22python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_nodejs22python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_nodejs22python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_nodejs22python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_nodejs22python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_nodejs22python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_nodejs22python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_nodejs22python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_nodejs20python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_nodejs20python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_nodejs20python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_nodejs20python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_nodejs20python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_nodejs20python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_nodejs20python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_nodejs20python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_nodejs22python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_nodejs22python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_nodejs22python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_nodejs22python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_nodejs22python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_nodejs22python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_nodejs22python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/datavzrd-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_nodejs22python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_nodejs20python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15465&branchName=main">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -8,4 +8,7 @@ conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
 test: native_and_emulated

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,6 +2,7 @@ bot:
   automerge: true
 build_platform:
   osx_arm64: osx_64
+  linux_aarch64: linux_64
 conda_build:
   pkg_format: '2'
 conda_forge_output_validation: true
@@ -10,5 +11,4 @@ github:
   tooling_branch_name: main
 provider:
   linux_aarch64: default
-  linux_ppc64le: default
 test: native_and_emulated


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
