### PR TITLE
Remove c_stdlib_version from conda_build_config

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,2 @@
-c_stdlib_version:        
-  - '10.13'  # [osx and x86]
 channel_sources:
   conda-forge/label/cargo-patch-dev,conda-forge


### PR DESCRIPTION
This pull request makes a minor update to the `recipe/conda_build_config.yaml` file by removing the `c_stdlib_version` specification for macOS.